### PR TITLE
Updated to improve readability

### DIFF
--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -17,7 +17,9 @@ concept Dog extends Animal {
 }
 ```
 
-Concepts can be declared `abstract` if it should not be instantiated (must be subclassed).
+A concept can be declared as an `abstract concept` if it is not intended to be instantiated. Any such `abstract concept` must have one or more subclasses.
+
+Concepts are typically used to structure data, based on shared properties.
 
 ## Identity
 
@@ -42,9 +44,11 @@ concept Product identified {
 }
 ```
 
+Identity is typically used to establish [relationships](https://docs.accordproject.org/docs/model-relationships.html) between concerto objects.
+
 ## Assets
 
-An asset is a class declaration that has a single `String` property which acts as an identifier. You can use the `modelManager.getAssetDeclarations` API to look up all assets.
+An asset is a class declaration that has at least one `String` property which acts as the identifier. An asset may have other properties, but will only have one identifier. You can use the `modelManager.getAssetDeclarations` API to look up all assets.
 
 ```js
 asset Vehicle identified by vin {
@@ -56,7 +60,7 @@ Assets are typically used in your models for the long-lived identifiable Things 
 
 ## Participants
 
-Participants are class declarations that have a single `String` property acting as an identifier. You can use the `modelManager.getParticipantDeclarations` API to look up all participants.
+Participants are class declarations that have at least one `String` property acting as the identifier. A participant may have other properties, but will only have one identifier. You can use the `modelManager.getParticipantDeclarations` API to look up all participants.
 
 ```js
 participant Customer identified by email {
@@ -68,19 +72,18 @@ Participants are typically used for the identifiable people or organizations in 
 
 ## Transactions
 
-Transactions are similar to participants in that they are also class declarations that have a single `String` property acting as an identifier. You can use the `modelManager.getTransactionDeclarations` API to look up all transactions.
+Transactions are similar to participants in that they are also class declarations that have a single `String` property acting as an identifier. A transaction may have other properties, but will only have one identifier. You can use the `modelManager.getTransactionDeclarations` API to look up all transactions.
 
 ```js
 transaction Order identified by orderId {
   o String orderId
 }
 ```
-
-Transactions are typically used in models for the identifiable business events or messages that are submitted by Participants to change the state of Assets: cart check out, change of address, identity verification, place order, etc.
+Transactions are used to model the [interactions between a contract or clause and the real world](https://docs.accordproject.org/docs/spec-execution.html). Transactions are used for both inbound messages (requests) and as the synchronous return values (responses) from the logic of clauses or contracts.
 
 ## Events
 
-Events are similar to participants in that they are also class declarations that have a single `String` property acting as an identifier. You can use the `modelManager.getEventDeclarations` API to look up all transactions.
+Events are similar to participants in that they are also class declarations that have a single `String` property acting as an identifier. An event may have other properties, but will only have one identifier. You can use the `modelManager.getEventDeclarations` API to look up all transactions.
 
 ```js
 event LateDelivery identified by eventId {
@@ -88,4 +91,4 @@ event LateDelivery identified by eventId {
 }
 ```
 
-Events are typically used in models for the identifiable business events or messages that are emitted by logic to signify that something of interest has occurred.
+Events are typically used in models for the identifiable business events or messages that are emitted by logic to signify that something of interest has occurred or to indicate that some asynchronous action should occur in the real-world, such as notifying a party to the contract that they need to take some action.


### PR DESCRIPTION
Proposed a few tweaks that I think will improve readability, including: 
- giving a very brief motivation for 'concepts' and 'identity';
- clarifying that there is only one identification string, but may be other properties; and
- added a few links to other resources.